### PR TITLE
Исправление недочетов и небольших ошибок

### DIFF
--- a/GUI/BaseForm.Designer.cs
+++ b/GUI/BaseForm.Designer.cs
@@ -37,7 +37,7 @@ namespace BazisGUI
         private void InitializeComponent()
         {
             components = new System.ComponentModel.Container();
-            var resources = new System.ComponentModel.ComponentResourceManager(typeof(BaseForm));
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(BaseForm));
             toolStripContainer = new ToolStripContainer();
             statusStrip = new StatusStrip();
             lblStatus = new ToolStripStatusLabel();
@@ -1299,14 +1299,14 @@ namespace BazisGUI
             // содержаниеToolStripMenuItem
             // 
             содержаниеToolStripMenuItem.Name = "содержаниеToolStripMenuItem";
-            содержаниеToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            содержаниеToolStripMenuItem.Size = new System.Drawing.Size(156, 22);
             содержаниеToolStripMenuItem.Text = "&Содержание";
             содержаниеToolStripMenuItem.Click += содержаниеToolStripMenuItem_Click;
             // 
             // опрограммеToolStripMenuItem
             // 
             опрограммеToolStripMenuItem.Name = "опрограммеToolStripMenuItem";
-            опрограммеToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            опрограммеToolStripMenuItem.Size = new System.Drawing.Size(156, 22);
             опрограммеToolStripMenuItem.Text = "&О программе...";
             опрограммеToolStripMenuItem.Click += опрограммеToolStripMenuItem_Click;
             // 

--- a/GUI/BaseForm.cs
+++ b/GUI/BaseForm.cs
@@ -596,14 +596,14 @@ namespace BazisGUI
 
         private void toolStripMenuItem2_Click(object sender, EventArgs e)
         {
-            var splitContainer = (SplitContainer)navigator.Parent.Parent;
-            splitContainer.Panel1Collapsed = false;
+            //var splitContainer = (SplitContainer)navigator.Parent.Parent;
+            splitContainer3.Panel1Collapsed = !splitContainer3.Panel1Collapsed;
         }
 
         private void toolStripMenuItem3_Click(object sender, EventArgs e)
         {
             var splitContainer = (SplitContainer)console.Parent.Parent;
-            splitContainer.Panel2Collapsed = false;
+            splitContainer.Panel2Collapsed = !splitContainer.Panel2Collapsed;
         }
 
 

--- a/GUI/BaseForm.cs
+++ b/GUI/BaseForm.cs
@@ -525,7 +525,9 @@ namespace BazisGUI
 
         private void webPageLabel_Click(object sender, EventArgs e)
         {
-            System.Diagnostics.Process.Start(webPageLabel.Text); //где path это путь к сайту
+            var url = $"https://{webPageLabel.Text}";
+            if(Uri.IsWellFormedUriString(url, UriKind.Absolute))
+                Process.Start(new ProcessStartInfo{ FileName = url, UseShellExecute = true });
         }
 
         private void сохранитькакToolStripMenuItem_Click(object sender, EventArgs e)

--- a/GUI/Console/ConsoleControl.Designer.cs
+++ b/GUI/Console/ConsoleControl.Designer.cs
@@ -30,7 +30,7 @@ namespace BazisGUI.Console
         /// </summary>
         private void InitializeComponent()
         {
-            var resources = new System.ComponentModel.ComponentResourceManager(typeof(ConsoleControl));
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(ConsoleControl));
             openFileDialog = new System.Windows.Forms.OpenFileDialog();
             toolStripMenuItem14 = new System.Windows.Forms.ToolStripMenuItem();
             toolStripMenuItem15 = new System.Windows.Forms.ToolStripMenuItem();
@@ -115,7 +115,7 @@ namespace BazisGUI.Console
             // 
             tlscOut.ContentPanel.Controls.Add(rtxbField);
             tlscOut.ContentPanel.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            tlscOut.ContentPanel.Size = new System.Drawing.Size(793, 217);
+            tlscOut.ContentPanel.Size = new System.Drawing.Size(787, 217);
             tlscOut.Dock = System.Windows.Forms.DockStyle.Fill;
             tlscOut.LeftToolStripPanelVisible = false;
             tlscOut.Location = new System.Drawing.Point(0, 20);
@@ -144,7 +144,7 @@ namespace BazisGUI.Console
             rtxbField.Location = new System.Drawing.Point(0, 0);
             rtxbField.Margin = new System.Windows.Forms.Padding(1);
             rtxbField.Name = "rtxbField";
-            rtxbField.Size = new System.Drawing.Size(793, 217);
+            rtxbField.Size = new System.Drawing.Size(787, 217);
             rtxbField.TabIndex = 2;
             rtxbField.Text = "";
             rtxbField.WordWrap = false;
@@ -169,7 +169,7 @@ namespace BazisGUI.Console
             toolStripEx1.Location = new System.Drawing.Point(0, 0);
             toolStripEx1.Name = "toolStripEx1";
             toolStripEx1.Padding = new System.Windows.Forms.Padding(3, 0, 3, 0);
-            toolStripEx1.Size = new System.Drawing.Size(31, 217);
+            toolStripEx1.Size = new System.Drawing.Size(37, 217);
             toolStripEx1.SplitButtonClickWidth = 13;
             toolStripEx1.SplitButtonHeight = 40;
             toolStripEx1.SplitButtonTriangleSize = 6;
@@ -189,6 +189,7 @@ namespace BazisGUI.Console
             spbDictionary.Margin = new System.Windows.Forms.Padding(0, 2, 0, 2);
             spbDictionary.Name = "spbDictionary";
             spbDictionary.Size = new System.Drawing.Size(25, 25);
+            spbDictionary.Text = "Справка";
             spbDictionary.TextImageRelation = System.Windows.Forms.TextImageRelation.Overlay;
             spbDictionary.Click += btnDictionary_Click;
             // 
@@ -202,7 +203,7 @@ namespace BazisGUI.Console
             toolStripButton1.ImageTransparentColor = System.Drawing.Color.Magenta;
             toolStripButton1.Name = "toolStripButton1";
             toolStripButton1.Size = new System.Drawing.Size(25, 25);
-            toolStripButton1.Text = "toolStripButton1";
+            toolStripButton1.Text = "Изменить фон";
             toolStripButton1.Click += btnBackGroundInfo_Click;
             // 
             // toolStripButton2
@@ -214,7 +215,7 @@ namespace BazisGUI.Console
             toolStripButton2.ImageTransparentColor = System.Drawing.Color.Magenta;
             toolStripButton2.Name = "toolStripButton2";
             toolStripButton2.Size = new System.Drawing.Size(25, 25);
-            toolStripButton2.Text = "toolStripButton2";
+            toolStripButton2.Text = "Очистить";
             toolStripButton2.Click += ClearAll_Click;
             // 
             // btnStartMacro
@@ -227,7 +228,7 @@ namespace BazisGUI.Console
             btnStartMacro.ImageTransparentColor = System.Drawing.Color.Magenta;
             btnStartMacro.Name = "btnStartMacro";
             btnStartMacro.Size = new System.Drawing.Size(25, 25);
-            btnStartMacro.Text = "toolStripButton4";
+            btnStartMacro.Text = "Запустить";
             btnStartMacro.Click += btnStartMacro_Click;
             // 
             // toolStripMenuItem32

--- a/GUI/Console/ConsoleControl.cs
+++ b/GUI/Console/ConsoleControl.cs
@@ -323,13 +323,14 @@ namespace BazisGUI.Console
                     var assembly = Assembly.GetExecutingAssembly();
                     var stream = assembly.GetManifestResourceStream("PrConsole.Resources.Stop.ico");
                     btnStartMacro.Image = new Bitmap(stream);
+                    btnStartMacro.Text = "Остановить";
                 }
                 else
                 {
                     var assembly = Assembly.GetExecutingAssembly();
                     var stream = assembly.GetManifestResourceStream("PrConsole.Resources.StartCheck.ico");
                     btnStartMacro.Image = new Bitmap(stream);
-
+                    btnStartMacro.Text = "Запустить";
                     trd.Abort();
 
                 }

--- a/GUI/Console/ConsoleControl.resx
+++ b/GUI/Console/ConsoleControl.resx
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
-    Microsoft ResX Schema 
+    Microsoft ResX Schema
 
     Version 2.0
 
@@ -48,7 +48,7 @@
     value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
     value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
@@ -127,24 +127,24 @@
   <data name="toolStripButton1.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAA4AAAAQCAYAAAAmlE46AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAERSURBVDhPlZK9TsNQDIUNSAwsiDFLQRVQ+6axAx0gvndg
-        ZGTkEdgQKytsTGw8BztvwMDOwMZOqcSPWooSAUqcNgqfZMk6Pseyri5AC1ToFgCWrN6IF7zLaGPd6o0o
-        09MudiKrN6KMDxlt7mifTuxsLp7xcdDtruZ9xlvHmuCZ9dRQpudBFK2UtdCnI03ovKxV8IwvzsGy1XP2
-        eftQGS+svqBMYwBYtIMye3HvQAWvkqSzVggq9G5N88jinirTPXihqRf6+mdNiy15E1KXL2hdfye0D+PI
-        C16XrgcIqZt4ceO6+adSGirjTSX0SxD8CIyftZDgq0/dpfVXUMGRinsrBYc+iU+tbyZ5QBmLFwwzfs03
-        O8CBy/FdP4kAAAAASUVORK5CYII=
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAEXSURBVDhPlZK/SgNBEMZHBQsbsbwmyqLJzl525zSJ3v4p
+        LC0tfQQ7sbXVzsrO57D3DSzsLezsjYJRopE9SLgbk+P8wcDwzfcNw7IADbCEdwCwwvVaPMl7i1ubXK/F
+        pfi8J1sJ12vJjXy0uL3runjKZwvxpv3UE2I99tbsnDgtz7nnD7nGl16SrJW10MVjp/GirFXwWr4qBatc
+        j+SmfeSMvOT6Ul/hGACW+aDMQdo5dCSvtW5tFMI+4YibFmHTjrMGH8ATTjzhzz9rUmyJTchUXNC4Zic0
+        DVsS757kTel6gJCp74FSY26eVYZDp+VtJTQlkPgMUnzx0IDEm8/UFfdXiOf0SX2UgkOv0zPum0sMOCOL
+        Fwxzfs0v2K+BcdGbMIYAAAAASUVORK5CYII=
 </value>
   </data>
   <data name="toolStripButton2.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAANCAYAAACgu+4kAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAFCSURBVDhPjZGxSsRAEIZXxMLeVhSiyczkMhtRuWQnWliJ
-        lfgIvoAIFrYKFjaCnYitzb2ED3APcI8gynViFD1RNncbcnue+MHfzM43O8kq9Q+24nhRNH4bTW8mwXP/
-        /E8kxSvDOLADXPyeacyJhifRVDZlo8kO6/nNNethuFC0gn3bXKRUi2NhKos1OvbdCsNwMyFMSabUfC1m
-        FKwIYz+LQ8ko3C0Y+77QjNvOujOSREeGoaOUmnUDi5Q6MvzeCdnFMHwqYbxtx3BQr9Jg2gB3e57gtnJr
-        /MYmBvHwJZoDqDSMz/aVqqZ2a3VPGE592SEtuhCG15E8EA3Xfo/d4iyncMevO4Sha1J819HSsn9Wk2u4
-        E44O7U91tSyJkqqe0uVGEkXjxoic8cQwPtiIhp6k9GU0vAjDh2h8LDR2DcO97zl+ADZtmJElUbR4AAAA
-        AElFTkSuQmCC
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAFHSURBVDhPjZG/SsRAEIdXxMLeVpTEy+5MsrsRc3dJJlpY
+        iZX4CL6ACBa2ChY2gp2Irc29hA9wD3CPIB7XiVH8g7I5N+T2PPGDXzM73+wky9g/2AzDZdLwlWh8ySWc
+        ued/QjFcJggfZoCN2zOLBdLikRDLppwgmmEDt7lmIwiWisjfM81FjLU4EcSyWMcj163IpbieEmYkZWyx
+        FlP010jBKA0DSjHYKRSMXKEZu51x50jyw1yJHmNs3g4sYuy1x987JdskwntnpOCmG4r9epUGswbY2zMJ
+        W8yu8Rtt8MPqJZoDEMsOwtC8UtXUjVq7pMSJK1sownMSwbORxxuJK7fHbHGaYbDt1i2kRL8Tw6vmK6vu
+        WU2m+S0pfmB+qq2lksuqHuNFIjmfNH7IFBxnEu5NSIsBxfjZ1t4TCe8t162HQkE/V+LO9SzfbTCX/TWl
+        YlsAAAAASUVORK5CYII=
 </value>
   </data>
   <data name="btnStartMacro.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">

--- a/GUI/DataBases/DataBasePage.cs
+++ b/GUI/DataBases/DataBasePage.cs
@@ -1,10 +1,10 @@
-﻿using System;
+﻿using MaterialDB.Interfaces;
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Drawing;
-using System.IO;
+using System.Linq;
 using System.Windows.Forms;
-using MaterialDB.Interfaces;
 using UserControlsEx;
 using UserControlsEx.Graph;
 
@@ -94,7 +94,6 @@ namespace BazisGUI.DataBases
         {
             LoadEvent?.Invoke();
         }
-
         public virtual void ConvertToDictionary(DataSet dataSet)
         {
             throw new Exception("Метод не реализован!");
@@ -104,7 +103,6 @@ namespace BazisGUI.DataBases
         {
             throw new Exception("Метод не реализован!");
         }
-
         public List<GraphData> SetGraphData(DataTable table, string header, Color color, string xUnit, string yUnit)
         {
 
@@ -195,18 +193,6 @@ namespace BazisGUI.DataBases
         {
             throw new Exception("Метод не реализован!");
         }
-
-        private void TreeView_BeforeLabelEdit(object sender, NodeLabelEditEventArgs e)
-        {
-            if (!LabelEditFlag)
-                e.CancelEdit = true;
-        }
-
-        private void dataGridView_CellBeginEdit(object sender, DataGridViewCellCancelEventArgs e)
-        {
-            EditCell = dataGridView[e.ColumnIndex, e.RowIndex];
-            OldCellValue = dataGridView[e.ColumnIndex, e.RowIndex].Value;
-        }
         /// <summary>
         /// DataGridView_CellEndEdit
         /// </summary>
@@ -234,7 +220,34 @@ namespace BazisGUI.DataBases
             dtOut = dt.DefaultView.ToTable();
             return dtOut;
         }
+        public virtual void treeView_MouseDown(object sender, MouseEventArgs e)
+        {
+            throw new Exception("Метод не реализован!");
+        }
 
+        public string GetNextName(string basePrefix, IEnumerable<string> keys)
+        {
+            var numbers = keys
+                .Where(k => k.StartsWith(basePrefix))
+                .Select(k =>
+                {
+                    var suffix = k.Substring(basePrefix.Length);
+                    return int.TryParse(suffix, out int n) ? n : (int?)null;
+                })
+                .Where(n => n.HasValue)
+                .Select(n => n.Value)
+                .OrderBy(n => n)
+                .ToList();
+            int next = 1;
+            foreach (var n in numbers)
+            {
+                if (n == next)
+                    next++;
+                else
+                    break;
+            }
+            return $"{basePrefix}{next}";
+        }
         public virtual void AddDB_Click(object sender, EventArgs e)
         {
             LoadEvent?.Invoke();
@@ -244,7 +257,17 @@ namespace BazisGUI.DataBases
         {
             throw new Exception("Метод не реализован!");
         }
+        private void TreeView_BeforeLabelEdit(object sender, NodeLabelEditEventArgs e)
+        {
+            if (!LabelEditFlag)
+                e.CancelEdit = true;
+        }
 
+        private void dataGridView_CellBeginEdit(object sender, DataGridViewCellCancelEventArgs e)
+        {
+            EditCell = dataGridView[e.ColumnIndex, e.RowIndex];
+            OldCellValue = dataGridView[e.ColumnIndex, e.RowIndex].Value;
+        }
         private void treePanel_Paint(object sender, PaintEventArgs e)
         {
             var loc_y = toolStripContainer2.Location.Y;
@@ -281,9 +304,5 @@ namespace BazisGUI.DataBases
             e.Graphics.DrawString("График", Font, new SolidBrush(System.Drawing.Color.Black), 15, 0);
         }
 
-        public virtual void treeView_MouseDown(object sender, MouseEventArgs e)
-        {
-            throw new Exception("Метод не реализован!");
-        }
     }
 }

--- a/GUI/DataBases/FunctionDataBasePage.cs
+++ b/GUI/DataBases/FunctionDataBasePage.cs
@@ -214,17 +214,16 @@ namespace BazisGUI.DataBases
                 var dbPath = string.Empty;
                 var name = string.Empty;
                 dbPath = Directory.GetFiles(Application.StartupPath, "functions_draft.txt", SearchOption.AllDirectories)[0];
-                name = "Новая_функция";
+                name = GetNextName("Новая_функция_");
 
                 var dataSet = Loader.LoadDataBase(dbPath);
                 var function = ConvertToFunctions(dataSet);
 
                 var oldName = function.Last().Key;
                 var values = function.Last().Value;
-                var newName = oldName.Replace(name, $"{name}_{number}");
  
-                values.Name = newName;
-                Functions.Add(newName, values);
+                values.Name = name;
+                Functions.Add(name, values);
 
                 AddTreeNode(values);
             }
@@ -320,6 +319,29 @@ namespace BazisGUI.DataBases
             base.OpenFileDB_Click(sender, e);
         }
 
+        private string GetNextName(string basePrefix)
+        {
+            var numbers = Functions.Keys
+                .Where(k => k.StartsWith(basePrefix))
+                .Select(k =>
+                {
+                    var suffix = k.Substring(basePrefix.Length);
+                    return int.TryParse(suffix, out int n) ? n : (int?)null;
+                })
+                .Where(n => n.HasValue)
+                .Select(n => n.Value)
+                .OrderBy(n => n)
+                .ToList();
+            int next = 1;
+            foreach (var n in numbers)
+            {
+                if (n == next)
+                    next++;
+                else
+                    break;
+            }
+            return $"{basePrefix}{next}";
+        }
         private FunctionDBData ConvertToFunctions(DataSet dataSet)
         {
             var functions = new FunctionDBData();

--- a/GUI/DataBases/FunctionDataBasePage.cs
+++ b/GUI/DataBases/FunctionDataBasePage.cs
@@ -214,7 +214,7 @@ namespace BazisGUI.DataBases
                 var dbPath = string.Empty;
                 var name = string.Empty;
                 dbPath = Directory.GetFiles(Application.StartupPath, "functions_draft.txt", SearchOption.AllDirectories)[0];
-                name = GetNextName("Новая_функция_");
+                name = GetNextName("Новая_функция_", Functions.Keys);
 
                 var dataSet = Loader.LoadDataBase(dbPath);
                 var function = ConvertToFunctions(dataSet);
@@ -319,29 +319,6 @@ namespace BazisGUI.DataBases
             base.OpenFileDB_Click(sender, e);
         }
 
-        private string GetNextName(string basePrefix)
-        {
-            var numbers = Functions.Keys
-                .Where(k => k.StartsWith(basePrefix))
-                .Select(k =>
-                {
-                    var suffix = k.Substring(basePrefix.Length);
-                    return int.TryParse(suffix, out int n) ? n : (int?)null;
-                })
-                .Where(n => n.HasValue)
-                .Select(n => n.Value)
-                .OrderBy(n => n)
-                .ToList();
-            int next = 1;
-            foreach (var n in numbers)
-            {
-                if (n == next)
-                    next++;
-                else
-                    break;
-            }
-            return $"{basePrefix}{next}";
-        }
         private FunctionDBData ConvertToFunctions(DataSet dataSet)
         {
             var functions = new FunctionDBData();

--- a/GUI/DataBases/MaterialsDataBasePage.cs
+++ b/GUI/DataBases/MaterialsDataBasePage.cs
@@ -517,7 +517,7 @@ namespace BazisGUI.DataBases
                 var dbPath = string.Empty;
                 var name = string.Empty;
                 dbPath = Directory.GetFiles(Application.StartupPath, "materials_draft.txt", SearchOption.AllDirectories)[0];
-                name = "Новый_материал";
+                name = GetNextName("Новый_материал_");
 
                 var dataSet = Loader.LoadDataBase(dbPath);
                 var material = ConvertToMaterials(dataSet);
@@ -525,11 +525,10 @@ namespace BazisGUI.DataBases
                 var lastItem = material.Last();
                 var oldName = lastItem.Key;
                 var values = lastItem.Value;
-                var newName = oldName.Replace(name, $"{name}_{number}");
-                Materials.Remove(oldName);
-                values.Name = newName;
-                Materials.Add(newName, values);
 
+                Materials.Remove(oldName);
+                values.Name = name;
+                Materials.Add(name, values);
 
                 AddTreeNode(values);
             }
@@ -599,7 +598,29 @@ namespace BazisGUI.DataBases
             }
         }
 
-        private void UpdatePhaseColumns(IEnumerable<DataTable> tables, string [] phaseNames)
+        private string GetNextName(string basePrefix)
+        {
+            var numbers = Materials.Keys
+                .Where(k => k.StartsWith(basePrefix))
+                .Select(k =>
+                {
+            var suffix = k.Substring(basePrefix.Length);
+            return int.TryParse(suffix, out int n) ? n : (int?)null;})
+                .Where(n => n.HasValue)
+                .Select(n => n.Value)
+                .OrderBy(n => n)
+                .ToList();
+            int next = 1;
+            foreach (var n in numbers)
+            {
+                if (n == next)
+                    next++;
+                else
+                    break;
+            }
+            return $"{basePrefix}{next}";
+        }
+private void UpdatePhaseColumns(IEnumerable<DataTable> tables, string [] phaseNames)
         {
             foreach (var table in tables)
             {

--- a/GUI/DataBases/MaterialsDataBasePage.cs
+++ b/GUI/DataBases/MaterialsDataBasePage.cs
@@ -517,7 +517,7 @@ namespace BazisGUI.DataBases
                 var dbPath = string.Empty;
                 var name = string.Empty;
                 dbPath = Directory.GetFiles(Application.StartupPath, "materials_draft.txt", SearchOption.AllDirectories)[0];
-                name = GetNextName("Новый_материал_");
+                name = GetNextName("Новый_материал_", Materials.Keys);
 
                 var dataSet = Loader.LoadDataBase(dbPath);
                 var material = ConvertToMaterials(dataSet);
@@ -598,29 +598,7 @@ namespace BazisGUI.DataBases
             }
         }
 
-        private string GetNextName(string basePrefix)
-        {
-            var numbers = Materials.Keys
-                .Where(k => k.StartsWith(basePrefix))
-                .Select(k =>
-                {
-            var suffix = k.Substring(basePrefix.Length);
-            return int.TryParse(suffix, out int n) ? n : (int?)null;})
-                .Where(n => n.HasValue)
-                .Select(n => n.Value)
-                .OrderBy(n => n)
-                .ToList();
-            int next = 1;
-            foreach (var n in numbers)
-            {
-                if (n == next)
-                    next++;
-                else
-                    break;
-            }
-            return $"{basePrefix}{next}";
-        }
-private void UpdatePhaseColumns(IEnumerable<DataTable> tables, string [] phaseNames)
+        private void UpdatePhaseColumns(IEnumerable<DataTable> tables, string [] phaseNames)
         {
             foreach (var table in tables)
             {

--- a/GUI/Methods/PropertyPanel/ChangeSurfProperties.cs
+++ b/GUI/Methods/PropertyPanel/ChangeSurfProperties.cs
@@ -1,12 +1,7 @@
 ﻿using BazisGUI.Extensions;
 using BazisGUI.PropertiesPanel;
 using GmshApi;
-using Model.GeometryObjects;
-using Model.Interfaces;
-using Project.Interfaces.Tasks;
-using System.Collections.Generic;
 using System.Linq;
-using static System.Windows.Forms.VisualStyles.VisualStyleElement;
 
 namespace BazisGUI
 {
@@ -58,8 +53,7 @@ namespace BazisGUI
 
                 project.GmshController.SetTransfiniteSurface(number, arrangement, points.ToArray());
                 //GmshController.Gmsh.Model.Mesh.SetTransfiniteSurface(number, arrangement, points.ToArray());
-            }
-            
+            } 
         }
     }
 }

--- a/GUI/SettingsControls/SettingsControl.Designer.cs
+++ b/GUI/SettingsControls/SettingsControl.Designer.cs
@@ -200,7 +200,6 @@ namespace BazisGUI.SettingsControls
             clslTransparency.LargeChange = 50U;
             clslTransparency.Location = new System.Drawing.Point(5, 719);
             clslTransparency.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
-            clslTransparency.Maximum = 99;
             clslTransparency.Name = "clslTransparency";
             clslTransparency.ShowTextValue = true;
             clslTransparency.Size = new System.Drawing.Size(393, 29);


### PR DESCRIPTION
1 При попытке открыть настройки выбрасывается исключение. 
<img width="1779" height="464" alt="image" src="https://github.com/user-attachments/assets/c3764d27-7e00-43be-ab26-fc524b5d760d" />
Исключение связано с тем, что clslTransparency имело maxValue 99

2. В рамках тестирования был обнаружил ошибочный сценарий (впервые обнаружен на Simmax):
-добавление 2-х новых материалов (или функций)
-удаление первого добавленного материала (или функции) с меньшим номером
-попытка добавления нового материала (или функции)
-возникновение ошибки в messageBox

3. При нажатии в главном меню на кнопку вид навигатор/консоль ожидаемого эффекта не возникало.