### PR TITLE
Восстановлена работоспособность инструмента "продвинутый выбор"

### DIFF
--- a/GUI/AdvanceSelection/ControlsForSelect/GeomSelect.Designer.cs
+++ b/GUI/AdvanceSelection/ControlsForSelect/GeomSelect.Designer.cs
@@ -52,6 +52,7 @@ namespace BazisGUI.AdvanceSelection.ControlsForSelect
             rbtVolume.Checked = true;
             rbtVolume.ForeColor = System.Drawing.SystemColors.ControlText;
             rbtVolume.Name = "rbtVolume";
+            rbtVolume.AccessibleName = "GeomSelect.Volumes";
             rbtVolume.TabStop = true;
             rbtVolume.Tag = "";
             // 
@@ -59,12 +60,14 @@ namespace BazisGUI.AdvanceSelection.ControlsForSelect
             // 
             resources.ApplyResources(rbtSurface, "rbtSurface");
             rbtSurface.Name = "rbtSurface";
+            rbtSurface.AccessibleName = "GeomSelect.Surfaces";
             rbtSurface.TabStop = true;
             // 
             // rbtCurve
             // 
             resources.ApplyResources(rbtCurve, "rbtCurve");
             rbtCurve.Name = "rbtCurve";
+            rbtCurve.AccessibleName = "GeomSelect.Curves";
             rbtCurve.TabStop = true;
             // 
             // GeomSelect

--- a/GUI/AdvanceSelection/ControlsForSelect/GeomSelect.cs
+++ b/GUI/AdvanceSelection/ControlsForSelect/GeomSelect.cs
@@ -37,7 +37,7 @@ namespace BazisGUI.AdvanceSelection.ControlsForSelect
         {
             foreach (var rb in generalPanel.Controls.OfType<RadioButton>())
                 if (rb.Checked)
-                    return GetDimm(rb.AccessibleName);
+                    return GetDim(rb.AccessibleName);
             return -1;
         }
 
@@ -48,7 +48,7 @@ namespace BazisGUI.AdvanceSelection.ControlsForSelect
             rbtCurve.Enabled = curve;
         }
 
-        private int GetDimm(string rbtText) 
+        private int GetDim(string rbtText) 
         {
             return Enum.Parse<SelectionType>(rbtText.Split("GeomSelect.")[1]) switch
             {

--- a/GUI/Methods/Scene/Buttons/AdvanceSelection.cs
+++ b/GUI/Methods/Scene/Buttons/AdvanceSelection.cs
@@ -60,7 +60,7 @@ namespace BazisGUI
                 if (IsMesh())
                 {
                     var selectionControl = new MeshSelect(SelectedObjects);
-                    //OnChangeSelectedObjectsEvent += selectionControl.SetAvailableModes;
+                    OnChangeSelectedObjectsEvent += selectionControl.SetAvailableModes;
                     //selectionControl.SelectInDirection += OnReverseChanged;
                     selectionControl.CloseForm += RefreshForm;
 
@@ -71,7 +71,7 @@ namespace BazisGUI
                 else if (IsGeometry())
                 {
                     var selectionControl = new GeomSelect(SelectedObjects);
-                    //OnChangeSelectedObjectsEvent += selectionControl.SetAvailableModes;
+                    OnChangeSelectedObjectsEvent += selectionControl.SetAvailableModes;
                     selectionControl.CloseForm += RefreshForm;
 
                     form.ClientSize = selectionControl.Size;
@@ -343,7 +343,7 @@ namespace BazisGUI
             var mesh = form.Controls.OfType<MeshSelect>().FirstOrDefault();
             if (mesh != null)
             {
-                //OnChangeSelectedObjectsEvent -= mesh.SetAvailableModes;
+                OnChangeSelectedObjectsEvent -= mesh.SetAvailableModes;
                 //mesh.SelectInDirection -= OnReverseChanged;
                 mesh.CloseForm -= RefreshForm;
                 mesh.Dispose();
@@ -353,7 +353,7 @@ namespace BazisGUI
             var geom = form.Controls.OfType<GeomSelect>().FirstOrDefault();
             if (geom != null)
             {
-                //OnChangeSelectedObjectsEvent -= geom.SetAvailableModes;
+                OnChangeSelectedObjectsEvent -= geom.SetAvailableModes;
                 geom.CloseForm -= RefreshForm;
                 geom.Dispose();
             }

--- a/GUI/Methods/Scene/Buttons/SelectObjects.cs
+++ b/GUI/Methods/Scene/Buttons/SelectObjects.cs
@@ -14,7 +14,7 @@ namespace BazisGUI
     {
         
         Dictionary<SelectionType, Button> objButtons = new();
-        //public event Action<string> OnChangeSelectedObjectsEvent;
+        public event Action<SelectionType> OnChangeSelectedObjectsEvent;
         /// <summary>
         /// Временный выбранный объект для работы со свойствами через сцену
         /// </summary>
@@ -63,7 +63,7 @@ namespace BazisGUI
         {
             var btn = sender as Button;
             SelectedObjects = Enum.Parse<SelectionType>(btn.AccessibleName.Split("SelectObjects.btnSelect.")[1]);
-            //OnChangeSelectedObjectsEvent?.Invoke(SelectedObjects);
+            OnChangeSelectedObjectsEvent?.Invoke(SelectedObjects);
             btnSelect.Tag = false;
 
             foreach (var item in objButtons)


### PR DESCRIPTION
Был произведен анализ причин возникновения проблемы. Выявлены следующие изменения повлекшие отказ работы инструмента:
- Отключение (закомментировано) события OnChangeSelectedObjectsEvent привело к заморозке интерфейса инструмента в стартовом положении. Смена SelectedObject не оповещала интерфейс.
- В метод GetDim вместо rbt.Text стали передавать rb.AccessibleName, но имена в дизайнере прописаны не были, что приводило к исключению при попытке парсить в enum.

[Ссылка на задачу](https://github.com/ONEGOCH/BazisCAE.GUI/issues/355)